### PR TITLE
Fixed error in instance getter

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1cf741a97e14a1c2bf44a76bd5e2507e",
+    "content-hash": "d65ad6483451e48e0a35ecf5619d2b4a",
     "packages": [],
     "packages-dev": [
         {

--- a/src/Commands/SiteDefrostCommand.php
+++ b/src/Commands/SiteDefrostCommand.php
@@ -40,15 +40,13 @@ class SiteDefrostCommand extends SiteCommand implements SiteAwareInterface
    * 
    * @param string $site Site to unfreeze.
    */
-  public function defrost(string $site): self
+  public function defrost(string $site)
   {
     try {
-      $this->setSiteInstance($site);
+      $this->setSiteInstance($site)->runner();
     } catch (TerminusException $ex) {
       $this->io()->error($ex->getMessage());
     }
-
-    return $this->runner();
   }
 
   /**
@@ -74,10 +72,6 @@ class SiteDefrostCommand extends SiteCommand implements SiteAwareInterface
   {
     if (!empty($this->siteName)) {
       return (string) $this->siteName;
-    }
-
-    if ( $this->getSiteInstance() instanceof Site ){
-      return $this->getSiteInstance()->get('name');
     }
 
     return '';
@@ -120,7 +114,7 @@ class SiteDefrostCommand extends SiteCommand implements SiteAwareInterface
   protected function getSiteInstance(): Site
   {
     if (!$this->siteInstance instanceof Site) {
-      throw new TerminusException(sprintf('Could not find the site %s', $this->siteName));
+      throw new TerminusException(sprintf('Could not find the site %s', $this->getSiteName()));
     }
 
     return $this->siteInstance;


### PR DESCRIPTION
Changes the logic in getting a site name which caused a recursion error when it tried to get a name before the site instance was set up.