### PR TITLE
Fix site names breaking on 'test'

### DIFF
--- a/src/Commands/SiteDefrostCommand.php
+++ b/src/Commands/SiteDefrostCommand.php
@@ -151,16 +151,14 @@ class SiteDefrostCommand extends SiteCommand implements SiteAwareInterface
     }
 
     try {
-      $regexes = [
-        // URLs or name with leading env, up to the site name.
-        '/^(https?:\/\/)?(dev|test|live)-/i',
-        // Names with trailing ".env" after site name.
-        '/\.(dev|test|live)/i',
-        // Platform URLs and anything after.
-        '/\.pantheonsite\.io(?:.+)?/i'
-      ];
-
-      $siteName = preg_replace($regexes, '', $siteName);
+      // Try to clean up any URLs or environments passed with the site name.
+      $siteName = preg_replace('#https?:\/\/#', '', $siteName );
+      $siteName = preg_replace('#\.pantheonsite\.io/(?:.+)$#', '', $siteName);
+      /* Sites will only be frozen if they have a live env, so we're going to ignore 'test', 'live', and multidev envs for now.
+       * @todo Find a better RegEx to capture all env types while still allowing 'test-site-name', since many of our sites have
+       * 'test' or 'testing' as the site name even though 'test' is a reserved env name.
+       */
+      $siteName = preg_replace('#(^dev-)|(\.dev$)#', '', $siteName);
 
       if (empty($siteName)) {
         throw new TerminusException(sprintf('Could not validate site name %s.', $siteName));


### PR DESCRIPTION
Although 'test' is a reserved environment name, it's being used in many
sites that are getting frozen. Since the current RegEx treats 'test' as
an environment name, it strips that out and breaks the command from
thawing out sites like 'test-my-cool-feature'.

This dumbs down the check a bit and only looks for 'dev' as the
environment name, since it's the most likely env to get passed (live
sites don't get frozen). It also splits the replacement into 3 calls
for ease of reading and debugging until a better RegEx comes along.